### PR TITLE
Update service to add more years to the select menu

### DIFF
--- a/projects/ng-payment-card/src/lib/service/payment-card.service.spec.ts
+++ b/projects/ng-payment-card/src/lib/service/payment-card.service.spec.ts
@@ -104,8 +104,8 @@ describe('PaymentCardPaymentCardService', () => {
   });
 
   describe('getYears', () => {
-    it('should return array of years with two in the past and 4 in the future', () => {
-      expect(PaymentCardService.getYears().length).toEqual(7);
+    it('should return array of years with two in the past and 6 in the future', () => {
+      expect(PaymentCardService.getYears().length).toEqual(9);
     });
   });
 });

--- a/projects/ng-payment-card/src/lib/service/payment-card.service.ts
+++ b/projects/ng-payment-card/src/lib/service/payment-card.service.ts
@@ -44,7 +44,7 @@ export class PaymentCardService {
   public static getYears(): Array<number> {
     const years: Array<number> = [];
     const year = new Date().getFullYear();
-    for (let i = -2; i < 5; i++) {
+    for (let i = -2; i < 7; i++) {
       years.push(year + i);
     }
     return years;


### PR DESCRIPTION
We are getting complaints from users that they cannot use the payment form because their card's expiration year is not included in the select menu. 